### PR TITLE
Pin scaffeine version to 4.x in Scala Steward config

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,3 @@
+updates.pin = [
+  { groupId = "com.github.blemale", artifactId = "scaffeine", version = "4." }
+]


### PR DESCRIPTION
Scaffeine 5.x requires jdk11+