### PR TITLE
Add Scala 3 build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,10 @@ updates:
       - "catostrophe"
     labels:
       - "dependency-update"
+    ignore:
+      # managed by sbt-github-actions
+      - dependency-name: "olafurpg/setup-scala"
+      - dependency-name: "actions/checkout"
+      - dependency-name: "actions/cache"
+      - dependency-name: "actions/upload-artifact"
+      - dependency-name: "actions/download-artifact"

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -28,6 +28,8 @@ pull_request_rules:
           - check-success~=Test \(ubuntu-latest, 2\.12\.\d+, adopt@1\.11\)
           - check-success~=Test \(ubuntu-latest, 2\.13\.\d+, adopt@1\.8\)
           - check-success~=Test \(ubuntu-latest, 2\.13\.\d+, adopt@1\.11\)
+          - check-success~=Test \(ubuntu-latest, 3\.\d+\.\d+, adopt@1\.8\)
+          - check-success~=Test \(ubuntu-latest, 3\.\d+\.\d+, adopt@1\.11\)
     actions:
       merge:
         method: rebase
@@ -45,6 +47,8 @@ pull_request_rules:
           - check-success~=Test \(ubuntu-latest, 2\.12\.\d+, adopt@1\.11\)
           - check-success~=Test \(ubuntu-latest, 2\.13\.\d+, adopt@1\.8\)
           - check-success~=Test \(ubuntu-latest, 2\.13\.\d+, adopt@1\.11\)
+          - check-success~=Test \(ubuntu-latest, 3\.\d+\.\d+, adopt@1\.8\)
+          - check-success~=Test \(ubuntu-latest, 3\.\d+\.\d+, adopt@1\.11\)
     actions:
       merge:
         method: rebase

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.6, 2.12.14]
+        scala: [2.13.6, 2.12.14, 3.0.1]
         java: [adopt@1.8, adopt@1.11]
     runs-on: ${{ matrix.os }}
     steps:
@@ -116,6 +116,16 @@ jobs:
           name: target-${{ matrix.os }}-2.12.14-${{ matrix.java }}
 
       - name: Inflate target directories (2.12.14)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (3.0.1)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-3.0.1-${{ matrix.java }}
+
+      - name: Inflate target directories (3.0.1)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         run: sbt --client '++${{ matrix.scala }}; test'
 
       - name: Compress target directories
-        run: tar cf targets.tar target modules/tail-sampling-cache-store/target modules/tail-sampling-redis-store/target project/target
+        run: tar cf targets.tar target modules/tail-sampling-caffeine/target modules/tail-sampling-cache-store/target modules/tail-sampling-redis-store/target project/target
 
       - name: Upload target directories
         uses: actions/upload-artifact@v2

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,3 +1,3 @@
 updates.pin = [
-  { groupId = "com.github.blemale", artifactId = "scaffeine", version = "4." }
+  { groupId = "com.github.ben-manes.caffeine", artifactId = "caffeine", version = "2." }
 ]

--- a/build.sbt
+++ b/build.sbt
@@ -35,13 +35,21 @@ lazy val root = (project in file("."))
   .settings(name := "Trace4Cats Tail Sampling Extras")
   .aggregate(`tail-sampling-cache-store`, `tail-sampling-redis-store`)
 
+lazy val `tail-sampling-caffeine` = (project in file("modules/tail-sampling-caffeine"))
+  .settings(publishSettings)
+  .settings(
+    name := "trace4cats-tail-sampling-caffeine",
+    libraryDependencies ++= Seq(Dependencies.caffeine, Dependencies.catsEffectKernel, Dependencies.collectionCompat)
+  )
+
 lazy val `tail-sampling-cache-store` = (project in file("modules/tail-sampling-cache-store"))
   .settings(publishSettings)
   .settings(
     name := "trace4cats-tail-sampling-cache-store",
-    libraryDependencies ++= Seq(Dependencies.trace4catsTailSampling, Dependencies.scaffeine),
+    libraryDependencies ++= Seq(Dependencies.trace4catsTailSampling),
     libraryDependencies ++= Seq(Dependencies.trace4catsTestkit).map(_ % Test)
   )
+  .dependsOn(`tail-sampling-caffeine`)
 
 lazy val `tail-sampling-redis-store` = (project in file("modules/tail-sampling-redis-store"))
   .settings(publishSettings)
@@ -50,8 +58,8 @@ lazy val `tail-sampling-redis-store` = (project in file("modules/tail-sampling-r
     libraryDependencies ++= Seq(
       Dependencies.trace4catsTailSampling,
       Dependencies.redis4cats,
-      Dependencies.redis4catsLog4cats,
-      Dependencies.scaffeine
+      Dependencies.redis4catsLog4cats
     ),
     libraryDependencies ++= Seq(Dependencies.trace4catsTestkit, Dependencies.embeddedRedis).map(_ % Test)
   )
+  .dependsOn(`tail-sampling-caffeine`)

--- a/ci-release.sbt
+++ b/ci-release.sbt
@@ -1,5 +1,9 @@
 ThisBuild / scalaVersion := Dependencies.Versions.scala213
-ThisBuild / crossScalaVersions := Seq(Dependencies.Versions.scala213, Dependencies.Versions.scala212)
+ThisBuild / crossScalaVersions := Seq(
+  Dependencies.Versions.scala213,
+  Dependencies.Versions.scala212,
+  Dependencies.Versions.scala3
+)
 ThisBuild / githubWorkflowTargetTags ++= Seq("v*")
 ThisBuild / githubWorkflowJavaVersions := Seq("adopt@1.8", "adopt@1.11")
 

--- a/modules/tail-sampling-cache-store/src/main/scala/io/janstenpickle/trace4cats/sampling/tail/cache/LocalCacheSampleDecisionStore.scala
+++ b/modules/tail-sampling-cache-store/src/main/scala/io/janstenpickle/trace4cats/sampling/tail/cache/LocalCacheSampleDecisionStore.scala
@@ -2,33 +2,28 @@ package io.janstenpickle.trace4cats.sampling.tail.cache
 
 import cats.effect.kernel.Sync
 import cats.syntax.functor._
-import com.github.blemale.scaffeine.Scaffeine
 import io.janstenpickle.trace4cats.model.{SampleDecision, TraceId}
 import io.janstenpickle.trace4cats.sampling.tail.SampleDecisionStore
+import io.janstenpickle.trace4cats.sampling.tail.caffeine.CaffeineCache
 
 import scala.concurrent.duration._
 
 object LocalCacheSampleDecisionStore {
   def apply[F[_]: Sync](ttl: FiniteDuration = 5.minutes, maximumSize: Option[Long] = None): F[SampleDecisionStore[F]] =
-    Sync[F]
-      .delay {
-        val builder = Scaffeine().expireAfterAccess(ttl)
-
-        maximumSize.fold(builder)(builder.maximumSize).build[TraceId, SampleDecision]()
-      }
+    CaffeineCache[F, TraceId, SampleDecision](ttl, maximumSize)
       .map { cache =>
         new SampleDecisionStore[F] {
           override def getDecision(traceId: TraceId): F[Option[SampleDecision]] =
-            Sync[F].delay(cache.getIfPresent(traceId))
+            cache.getIfPresent(traceId)
 
           override def storeDecision(traceId: TraceId, sampleDecision: SampleDecision): F[Unit] =
-            Sync[F].delay(cache.put(traceId, sampleDecision))
+            cache.put(traceId, sampleDecision)
 
           override def batch(traceIds: Set[TraceId]): F[Map[TraceId, SampleDecision]] =
-            Sync[F].delay(cache.getAllPresent(traceIds))
+            cache.getAllPresent(traceIds)
 
           override def storeDecisions(decisions: Map[TraceId, SampleDecision]): F[Unit] =
-            Sync[F].delay(cache.putAll(decisions))
+            cache.putAll(decisions)
         }
       }
 }

--- a/modules/tail-sampling-caffeine/src/main/scala/io/janstenpickle/trace4cats/sampling/tail/caffeine/CaffeineCache.scala
+++ b/modules/tail-sampling-caffeine/src/main/scala/io/janstenpickle/trace4cats/sampling/tail/caffeine/CaffeineCache.scala
@@ -1,0 +1,36 @@
+package io.janstenpickle.trace4cats.sampling.tail.caffeine
+
+import cats.effect.kernel.Sync
+import cats.syntax.functor._
+import com.github.benmanes.caffeine.cache.{Caffeine => JCaffeine}
+
+import scala.concurrent.duration.FiniteDuration
+import scala.jdk.CollectionConverters._
+import scala.jdk.DurationConverters._
+
+trait CaffeineCache[F[_], K, V] {
+  def put(key: K, value: V): F[Unit]
+  def putAll(map: Map[K, V]): F[Unit]
+  def getIfPresent(key: K): F[Option[V]]
+  def getAllPresent(keys: Iterable[K]): F[Map[K, V]]
+}
+
+object CaffeineCache {
+  def apply[F[_], K, V](expiresAfter: FiniteDuration, maxSize: Option[Long])(implicit
+    F: Sync[F]
+  ): F[CaffeineCache[F, K, V]] =
+    F.delay {
+      val builder = JCaffeine
+        .newBuilder()
+        .expireAfterAccess(expiresAfter.toJava)
+      maxSize.fold(builder)(builder.maximumSize).build[K, V]()
+    }.map(underlying =>
+      new CaffeineCache[F, K, V] {
+        def put(key: K, value: V): F[Unit] = F.delay(underlying.put(key, value))
+        def putAll(map: Map[K, V]): F[Unit] = F.delay(underlying.putAll(map.asJava))
+        def getIfPresent(key: K): F[Option[V]] = F.delay(Option(underlying.getIfPresent(key)))
+        def getAllPresent(keys: Iterable[K]): F[Map[K, V]] =
+          F.delay(underlying.getAllPresent(keys.asJava).asScala.toMap)
+      }
+    )
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,8 +4,9 @@ object Dependencies {
   object Versions {
     val scala212 = "2.12.14"
     val scala213 = "2.13.6"
+    val scala3 = "3.0.1"
 
-    val trace4cats = "0.12.0-RC2"
+    val trace4cats = "0.12.0-RC2+18-2de6b68e"
 
     val embeddedRedis = "0.7.3"
     val redis4cats = "1.0.0"
@@ -21,7 +22,7 @@ object Dependencies {
   lazy val embeddedRedis = "it.ozimov"            % "embedded-redis"      % Versions.embeddedRedis
   lazy val redis4cats = "dev.profunktor"         %% "redis4cats-effects"  % Versions.redis4cats
   lazy val redis4catsLog4cats = "dev.profunktor" %% "redis4cats-log4cats" % Versions.redis4cats
-  lazy val scaffeine = "com.github.blemale"      %% "scaffeine"           % Versions.scaffeine
+  lazy val scaffeine = ("com.github.blemale"     %% "scaffeine"           % Versions.scaffeine).cross(CrossVersion.for3Use2_13)
 
   lazy val kindProjector = ("org.typelevel" % "kind-projector"     % Versions.kindProjector).cross(CrossVersion.full)
   lazy val betterMonadicFor = "com.olegpy" %% "better-monadic-for" % Versions.betterMonadicFor

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,9 +8,11 @@ object Dependencies {
 
     val trace4cats = "0.12.0-RC2+18-2de6b68e"
 
+    val catsEffect = "3.2.1"
     val embeddedRedis = "0.7.3"
     val redis4cats = "1.0.0"
-    val scaffeine = "4.1.0"
+    val caffeine = "2.9.2"
+    val collectionCompat = "2.5.0"
 
     val kindProjector = "0.13.0"
     val betterMonadicFor = "0.3.1"
@@ -19,10 +21,12 @@ object Dependencies {
   lazy val trace4catsTailSampling = "io.janstenpickle" %% "trace4cats-tail-sampling" % Versions.trace4cats
   lazy val trace4catsTestkit = "io.janstenpickle"      %% "trace4cats-testkit"       % Versions.trace4cats
 
-  lazy val embeddedRedis = "it.ozimov"            % "embedded-redis"      % Versions.embeddedRedis
-  lazy val redis4cats = "dev.profunktor"         %% "redis4cats-effects"  % Versions.redis4cats
-  lazy val redis4catsLog4cats = "dev.profunktor" %% "redis4cats-log4cats" % Versions.redis4cats
-  lazy val scaffeine = ("com.github.blemale"     %% "scaffeine"           % Versions.scaffeine).cross(CrossVersion.for3Use2_13)
+  lazy val catsEffectKernel = "org.typelevel"          %% "cats-effect-kernel"      % Versions.catsEffect
+  lazy val embeddedRedis = "it.ozimov"                  % "embedded-redis"          % Versions.embeddedRedis
+  lazy val redis4cats = "dev.profunktor"               %% "redis4cats-effects"      % Versions.redis4cats
+  lazy val redis4catsLog4cats = "dev.profunktor"       %% "redis4cats-log4cats"     % Versions.redis4cats
+  lazy val caffeine = "com.github.ben-manes.caffeine"   % "caffeine"                % Versions.caffeine
+  lazy val collectionCompat = "org.scala-lang.modules" %% "scala-collection-compat" % Versions.collectionCompat
 
   lazy val kindProjector = ("org.typelevel" % "kind-projector"     % Versions.kindProjector).cross(CrossVersion.full)
   lazy val betterMonadicFor = "com.olegpy" %% "better-monadic-for" % Versions.betterMonadicFor


### PR DESCRIPTION
`scaffeine` doesn't have a Scala 3 artifact, but it's quite a simple wrapper, so should work smoothly in compat mode.

Depends on trace4cats/trace4cats#587